### PR TITLE
[FIX] payment_mollie_official: only send phone number if in E164 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,38 +3,46 @@
 </p>
 <h1 align="center">Mollie addon for Odoo 12</h1>
 
-## Install Python Package
-First install the python package "mollie-api-python": install mollie-api-python==1.2.0 or 2.1.0
-https://pypi.org/project/mollie-api-python/1.2.0/
+## Installing the Python packages
+You will need two Python packages for using this application.
+You can install both these requirements by running the following command:
+```
+pip3 install -R requirements.txt
+```
+Alternatively you can install them manually by doing `pip3 install mollie-api-python==1.2.0` and `pip3 install phonenumbers==8.10.3`
+You can find all the information about the dependencies on the following URL's:
+https://pypi.org/project/mollie-api-python/1.2.0/ <br/>
+https://pypi.org/project/phonenumbers/
 
 ## Installation
 For installation instructions please refer to the odoo docs:
 http://odoo-development.readthedocs.io/en/latest/odoo/usage/install-module.html#from-zip-archive-install
 
 ## Configuration
-Go to Invoicing section -> Payments -> Payment Acquirers -> Mollie.  
-Add API Keys (test and/or live) from your Mollie Account.
+Go to Invoicing > Payments > Payment Acquirers -> Mollie.
+Add the API Keys (test and/or live) from your Mollie Account here.
 
 ![alt text](/payment_mollie_official/static/description/crm_sc_02.PNG "Odoo mollie configuration example")
 
-When Mollie acquirer is configured correctly, you can see Mollie payment option at the time of checkout.
+When the Mollie payment acquirer is configured correctly, you can see the Mollie payment option at the time of checkout. You will not see Mollie as long as there are no payment methods configured on the payment acquirer. You will first have to add payment methods to your account on the Mollie website and then click on the "Update payment methods" button under the tab "Configuration" of the payment method Mollie in Odoo.
 
-Shopper will then be redirected to the Mollie payment method selection screen.
+The customer will then be redirected to the Mollie payment method selection screen.
 
 After a succesfull payment, a confirmation is shown to the shopper:
 
 ![alt text](/payment_mollie_official/static/description/Payment_Confirmation.png "Odoo mollie payment confirmation")
 
-For Refunds: Activate module Cancel Journal Entries
+If you'd like to use refunds you should activate the module "Cancel Journal Entries"
 
 ![alt text](/payment_mollie_official/static/description/Refund.png "Odoo mollie payment refunds")
 
 ![alt text](/payment_mollie_official/static/description/cancel_journal_entry.png "Odoo Cancel Journal Entry Module")
 
-For Specific Gateway Configuration: Go to gateways and change the Country, Amount or Currency that wil be used for specific gateways.
+If you want to use a specific gateway configuration you should configure it under the "Mollie" payment method by clicking on the smart button "Gateways" at the top of the form. You can change the country, amount or currency that will be used for specific gateways here.
 
 ![alt text](/payment_mollie_official/static/description/gateways.png "Odoo Mollie Gateways Configuration")
 
-For Updating the available Payment Methods: Go to configuration and click update. The list is generated automatically based on the payment methods active in your Mollie account.
+For updating the available payment Methodp: Go to configuration and click on the button "Update payment methods". The list is generated automatically based on the payment methods that are configured in your Mollie account.
 
 ![alt text](/payment_mollie_official/static/description/mollie_configuration.png "Odoo Mollie Payment Methods")
+

--- a/payment_mollie_official/data/payment_acquirer_data.xml
+++ b/payment_mollie_official/data/payment_acquirer_data.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <data>
         <template id="mollie_form">
             <input type="hidden" name="data_set" t-att-data-action-url="tx_url" data-remove-me=""/>
             <input type="hidden" name="OrderId" t-att-value="OrderId"/>
@@ -19,6 +20,8 @@
             <input type="hidden" name="Phone" t-att-value="Phone"/>
             <input name="Method" t-att-value="Method"/>
         </template>
+    </data>
+    <data noupdate="1">
         <record id="payment_acquirer_mollie" model="payment.acquirer">
             <field name="name">Mollie</field>
             <field name="image" type="base64" file="payment_mollie_official/static/src/img/mollie_icon.png"/>
@@ -41,5 +44,7 @@
                 </ul>
             </field>
         </record>
+    </data>
 </odoo>
+
 

--- a/payment_mollie_official/models/res_partner.py
+++ b/payment_mollie_official/models/res_partner.py
@@ -19,7 +19,12 @@
 #
 ###############################################################################
 
+import logging
+import phonenumbers
+
 from odoo import api, models
+
+_logger = logging.getLogger(__name__)
 
 
 class ResPartner(models.Model):
@@ -31,6 +36,24 @@ class ResPartner(models.Model):
         name_split = self.name.split(' ')
         givenName = name_split[0]
         familyName = self.name.replace(name_split[0], '')
+        phone = ''
+
+        """
+          Mollie only accepts E164 phone numbers. If the phone number is not in an E164 format Mollie will refuse
+          the payment, resulting in Odoo doing a rollback and the user being 'kicked' to the homepage again.
+          In this try/except we will do a check for it. If there is no valid phone number we'll give back '' which
+          will be accepted by Mollie (no phone number).
+        """
+        try:
+            raw_phone_number = self.phone
+            result = phonenumbers.parse(raw_phone_number, None)
+            if result:
+                phone = phonenumbers.format_number(result, phonenumbers.PhoneNumberFormat.E164)
+        except Exception as error:
+            _logger.warning('The customer filled in an invalid phone number format. The phone number is not in the '
+                            'E164 format which Mollie requires. We will not send it to Mollie.')
+            phone = ''
+
         res = {
             'givenName': givenName,
             'familyName': familyName or givenName,
@@ -41,6 +64,8 @@ class ResPartner(models.Model):
             'country': (self.country_id and
                         self.country_id.code) or 'nl',
             'email': self.email,
-            'phone': self.phone,
+            # Will set the phone if there is one, otherwise it gives back '' (no phone)
+            'phone': phone or '',
         }
         return res
+

--- a/payment_mollie_official/requirements.txt
+++ b/payment_mollie_official/requirements.txt
@@ -1,1 +1,0 @@
-mollie-api-python

--- a/payment_mollie_official/views/payment_views.xml
+++ b/payment_mollie_official/views/payment_views.xml
@@ -88,16 +88,21 @@
             <xpath expr='//field[@name="payment_icon_ids"]' position='replace'/>
             
             <xpath expr='//field[@name="journal_id"]' position='after'>
-                <div>
-                    <div class="row">
-                     <field name="payment_icon_ids" widget="many2many_tags" colspan="4" attrs="{'invisible': [('provider', '=', 'mollie')]}"/>
-                     <button name="update_available_mollie_methods"
-                                    string="_Update" class="oe_link"
+                <field name="payment_icon_ids" widget="many2many_tags" colspan="4" attrs="{'invisible': [('provider', '=', 'mollie')]}"/>
+            </xpath>
+            <xpath expr="//group[@name='acquirer_config']" position="before">
+                <group>
+                    <button name="update_available_mollie_methods"
+                                    string="_Update payment methods"
+                                    class="btn btn-info"
+                                    help="Will get all the configured payment methods from your Mollie account and will
+                                    make them available in Odoo automatically."
                                     groups="base.group_system"
                                     type="object"
                                     attrs="{'invisible': [('provider', '!=', 'mollie')]}"/>
-                    </div>
-                    <div class="row" title="Methods">
+                </group>
+                <group>
+
                   <field name="method_ids" colspan="4" nolabel="1" attrs="{'invisible': [('provider', '!=', 'mollie')]}">
                    <tree string="Supported method" create="false" editable="top">
                       <field name="sequence" widget="handle"/>
@@ -109,8 +114,7 @@
                       <field name="acquirer_id" invisible="1"/>
                    </tree>
                   </field>
-                 </div>
-                </div>
+                </group>
             </xpath>
         </field>
     </record>
@@ -135,3 +139,4 @@
         </field>
     </record>
 </odoo>
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mollie-api-python==2.1.0
+phonenumbers==8.10.3


### PR DESCRIPTION
Various improvements:
- Added phonenumbers as dependency to format phone numbers and to do checks (E164)
- Added update / noupdate tags on data so that API keys are not reset when updating the module
- Reformatted the mollie payment acquirer view to make it more transparent and clear
- Updated requirements.txt and uniformized into one file instead of 2 that where both not fully correct.