### PR TITLE
[FIX] payment_mollie_official: correctly evaluate acquirer conditions

### DIFF
--- a/payment_mollie_official/views/payment_templates.xml
+++ b/payment_mollie_official/views/payment_templates.xml
@@ -40,7 +40,7 @@
                 <t t-set="acquirers_count" t-value="len(acquirers) if acquirers else 0"/>
                 <t t-set="pms_count" t-value="len(pms) if pms else 0"/>
                 <t t-set="MAX_BRAND_LINE" t-value="3"/>
-                <t t-set="mollie_aq" t-value="0"/>
+                <t t-set="mollie_aq" t-value="False"/>
                 <t t-foreach="acquirers" t-as="acq">
                     <t t-if="acq.provider == 'mollie'">
                         <t t-set="mollie_aq" t-value="acq"/>
@@ -101,7 +101,7 @@
                         </div>
                     </t>
                 </t>
-                <t t-if="mollie_aq!='0' and website_sale_order">
+                <t t-if="mollie_aq and website_sale_order">
                     <t t-call="payment_mollie_official.mollie_payment_gateway_list"/>
                 </t>
                 <t t-foreach="pms" t-as="pm">


### PR DESCRIPTION
Case:
1. Configure Mollie and add an API test key.
2. Make sure the payment method Mollie is not set as active (archived) in the payment methods from the backend.
3. Create a webshop order and continue to https://mollie.odoo-cloud.nl/shop/payment

You'll get a traceback as the `t-value` "0" was not correctly evaluated causing Odoo to render the Mollie payment method its icons. As `mollie_aq` was empty it was not being able to access the record and values causing in the XML record giving a view traceback to the user.
By setting it to `False` first we can do a safe check to see if it is not False and then render the XML view with all Mollie payment icons (if active).