### PR TITLE
[IMP] payment_mollie_official: set description on new models

### DIFF
--- a/payment_mollie_official/models/mollie.py
+++ b/payment_mollie_official/models/mollie.py
@@ -115,6 +115,7 @@ class PaymentIcon(models.Model):
 
 class AcquirerMollieMethod(models.Model):
     _name = 'payment.acquirer.method'
+    _description = 'Mollie payment acquirer details'
     _order = 'sequence'
 
     name = fields.Char('Description', index=True,

--- a/payment_mollie_official/models/provider_log.py
+++ b/payment_mollie_official/models/provider_log.py
@@ -35,6 +35,7 @@ EXCEPTION_LOG_TYPE = {
 
 class ProviderLog(models.Model):
     _name = "provider.log"
+    _description = "Mollie provider log details"
     _order = "id desc"
 
     name = fields.Char(string="Description", required=True)


### PR DESCRIPTION
Without this description all Odoo instances would show warnings in the logs and Odoo.sh builds will be yellow as this could be improved.
After this PR is merged the warnings will no longer be logged and the app complies to the official Odoo requirements for model definitions.