### PR TITLE
[FIX] payment_mollie_official: make zip required

### DIFF
--- a/payment_mollie_official/views/payment_templates.xml
+++ b/payment_mollie_official/views/payment_templates.xml
@@ -125,5 +125,10 @@
         </xpath>
     </template>
     
+    <template id="mollie_zip_required" name="Mollie address inherit" inherit_id="website_sale.address">
+        <xpath expr="//input[@name='field_required']" position="attributes">
+            <attribute name="t-att-value">'zip'</attribute>
+        </xpath>
+    </template>
 </odoo>
 


### PR DESCRIPTION
Without this fix if a customer doesn't fill in the ZIP (which is not required) he/she will get the following error:
odoo.addons.payment_mollie_official.models.sale_order: ERROR! The following fields of the billingAddress are missing: postalCode

Gunther made a very similar PR but it has the phone and name included, which really shouldn't be done. Name is already required by default and we should not make a phone required as we technically don't need it. The phone part is already handled in another PR so the only thing that remains is the ZIP code.