### PR TITLE
[FIX] payment_mollie_official: allow spaces in SO sequences

### DIFF
--- a/payment_mollie_official/controllers/main.py
+++ b/payment_mollie_official/controllers/main.py
@@ -65,7 +65,7 @@ class MollieController(http.Controller):
         payload = {
             "description": description,
             "amount": amount,
-            "redirectUrl": "%s%s?reference=%s" % (base_url, self._redirect_url, orderid),
+            "redirectUrl": "%s%s?reference=%s" % (base_url, self._redirect_url, orderid.replace(' ', '%20'),
             "metadata": {
                 "order_id": orderid,
                 "customer": {


### PR DESCRIPTION
Before this fix you would get an internal server error when you would try to pay an order on an Odoo instance that has an order ID such as "SO 12345678"
If you would try to pay for "SO 12345678" this controller call would fail and you would get back the following response from the Mollie API's:
`response: {'error': {'message': 'The redirect URL is invalid', 'field': 'redirectUrl', 'type': 'request'}}`
The space in "SO 12345678" was not readable by Mollie which caused Mollie to send back an invalid redirect URL. Technically the directURL is correct but the API's fail on spaces. This fix converts ' ' into '%20' - the computer equivalent of a space.
This will allow Odoo users to use spaces in sequence names for orders without breaking the payment flows.