### PR TITLE
[10.0][FIX] Follow code conventions and prevent CI errors.

### DIFF
--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -1,11 +1,15 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 {
     'name': 'Mollie Payment Acquirer',
     'version': '1.10',
     'author': 'Mollie & BeOpen',
     'website': 'http://www.mollie.com',
     'category': 'eCommerce',
-    'description': "",
+    'description': """
+        Mollie helps businesses of all sizes to sell and build
+         more efficiently with a solid but easy-to-use payment solution.
+         Start growing your business today with effortless payments.
+    """,
     'depends': ['payment','website_sale'],
     'data': [
         'views/mollie.xml',

--- a/payment_mollie_official/data/mollie.xml
+++ b/payment_mollie_official/data/mollie.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
 
-        <record id="payment.payment_acquirer_mollie" model="payment.acquirer">
+        <record id="payment_acquirer_mollie" model="payment.acquirer">
             <field name="name">Online payment (Mollie)</field>
             <field name="image" type="base64" file="payment_mollie_official/static/src/img/mollie_icon.png"/>
             <field name="provider">mollie</field>


### PR DESCRIPTION
Code still contained deprecated elements like '<data>' and '<openerp>'. Apart from this there were two
issues that lead to WARNING messages in the runbot CI environment:
1. The module contained no description;
2. A record was created in the standard Odoo module payment, instead of in its own module.