### PR TITLE
[FIX] multi website base url

### DIFF
--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -43,6 +43,7 @@
         'views/payment_views.xml',
         'views/sale_order.xml',
         'views/payment_templates.xml',
+        'views/website.xml',
     ],
     'images': ['static/images/main_screenshot.png'],
     'installable': True,

--- a/payment_mollie_official/models/mollie.py
+++ b/payment_mollie_official/models/mollie.py
@@ -60,7 +60,10 @@ def get_as_base64(url):
 
 
 def get_base_url(env):
-    base_url = env['ir.config_parameter'].sudo().get_param('web.base.url')
+    base_url = (
+        env['website'].get_current_website().url or
+        env['ir.config_parameter'].sudo().get_param('web.base.url')
+    )
     return base_url
 
 
@@ -213,8 +216,7 @@ class AcquirerMollie(models.Model):
     @api.multi
     def mollie_form_generate_values(self, values):
         self.ensure_one()
-        base_url = self.env['ir.config_parameter'].sudo(
-        ).get_param('web.base.url')
+        base_url = get_base_url(self.env)
         mollie_api_key = self._get_mollie_api_keys(
             self.environment)['mollie_api_key']
         mollie_tx_values = dict(values)

--- a/payment_mollie_official/models/website.py
+++ b/payment_mollie_official/models/website.py
@@ -18,9 +18,14 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ###############################################################################
+from odoo import models, fields
 
-from . import mollie
-from . import provider_log
-from . import res_partner
-from . import sale_order
-from . import website
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    url = fields.Char(
+        string='Website URL',
+        help='Base url to use in redirects',
+        default=lambda s: s.env['ir.config_parameter'].sudo().get_param('web.base.url'),
+    )

--- a/payment_mollie_official/views/website.xml
+++ b/payment_mollie_official/views/website.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="mollie_view_website_form_inherit">
+        <field name="name">mollie.view.website.form.inherit</field>
+        <field name="model">website</field>
+        <field name="inherit_id" ref="website.view_website_form"/>
+        <field name="arch" type="xml">
+            <field name="domain" position="after">
+                <field name="url"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
web.base.url from parameters only allows set 1 website.
add value to website and default it to the web.base.url.parameter to allow multi website usage
also let mollie_form_generate_values use this function instead of changing it in 2 places