### PR TITLE
[IMP] payment_mollie_official: set model description

### DIFF
--- a/payment_mollie_official/models/voucher_lines.py
+++ b/payment_mollie_official/models/voucher_lines.py
@@ -9,6 +9,7 @@ _logger = logging.getLogger(__name__)
 
 class MollieVoucherLines(models.Model):
     _name = 'mollie.voucher.line'
+    _description = 'Mollie Voucher Line'
 
     category_id = fields.Many2one('product.category')
     mollie_voucher_category = fields.Selection(related="category_id.mollie_voucher_category", readonly=False)


### PR DESCRIPTION
Without this description logs & tests will gives a warning saying:
`2021-04-11 11:33:45,654 261297 WARNING your_database odoo.models: The model mollie.voucher.line has no _description`
By setting one this no longer pollutes the logs