### PR TITLE
Release new version v12.0.1.6

### DIFF
--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Payments',
-    'version': '12.0.1.5',
+    'version': '12.0.1.6',
     'category': 'eCommerce',
     'license': 'LGPL-3',
     'author': 'Mollie',

--- a/payment_mollie_official/models/mollie_method.py
+++ b/payment_mollie_official/models/mollie_method.py
@@ -12,10 +12,10 @@ class MolliePaymentMethod(models.Model):
     _description = 'Mollie payment method'
     _order = "sequence, id"
 
-    name = fields.Char()
+    name = fields.Char(translate=True)
     sequence = fields.Integer()
     parent_id = fields.Many2one('payment.acquirer')  # This will be always mollie
-    method_id_code = fields.Char()
+    method_id_code = fields.Char(string="Method code")
     payment_icon_ids = fields.Many2many('payment.icon', string='Supported Payment Icons')
     active = fields.Boolean(default=True)
     active_on_shop = fields.Boolean(string="Enabled on shop", default=True)
@@ -31,3 +31,11 @@ class MolliePaymentMethod(models.Model):
     payment_issuer_ids = fields.Many2many('mollie.payment.method.issuer', string='Issuers')
 
     country_ids = fields.Many2many('res.country', string='Country Availability')
+
+    fees_active = fields.Boolean('Add Extra Fees')
+    fees_dom_fixed = fields.Float('Fixed domestic fees')
+    fees_dom_var = fields.Float('Variable domestic fees (in percents)')
+    fees_int_fixed = fields.Float('Fixed international fees')
+    fees_int_var = fields.Float('Variable international fees (in percents)')
+
+    mollie_voucher_ids = fields.One2many('mollie.voucher.line', 'method_id', string='Mollie Voucher Config')

--- a/payment_mollie_official/models/payment_transection.py
+++ b/payment_mollie_official/models/payment_transection.py
@@ -35,6 +35,10 @@ class PaymentTransaction(models.Model):
         if request and request.params.get('mollie_issuer'):
             create_vals['mollie_payment_issuer'] = request.params.get('mollie_issuer')
 
+        if vals.get('fees') and isinstance(vals['fees'], dict):
+            payment_method = create_vals.get('mollie_payment_method')
+            vals['fees'] = vals['fees'].get(payment_method, 0)
+
         return create_vals
 
     def _mollie_form_get_tx_from_data(self, data):
@@ -59,7 +63,7 @@ class PaymentTransaction(models.Model):
 
         # Check what transection is with same amount
         amount = data.get('amount')
-        if amount and float_compare(float(amount.get('value', '0.0')), self.amount, 2) != 0:
+        if amount and float_compare(float(amount.get('value', '0.0')), self.amount + self.fees, 2) != 0:
             invalid_parameters.append(('Amount', amount.get('value'), '%.2f' % self.amount))
         if amount.get('currency') != self.currency_id.name:
             invalid_parameters.append(('Currency', data.get('currency'), self.currency_id.name))

--- a/payment_mollie_official/models/voucher_lines.py
+++ b/payment_mollie_official/models/voucher_lines.py
@@ -9,7 +9,15 @@ _logger = logging.getLogger(__name__)
 
 class MollieVoucherLines(models.Model):
     _name = 'mollie.voucher.line'
+    _description = 'Mollie Voucher Line'
 
+    def _default_voucher_category(self):
+        """ We moved field from acquirer to method line.
+            This will migrate existing lines to voucher method.
+        """
+        return self.env['mollie.payment.method'].with_context(active_test=False).search([('method_id_code', '=', 'voucher')], limit=1)
+
+    method_id = fields.Many2one('mollie.payment.method', default=_default_voucher_category)
     category_id = fields.Many2one('product.category')
     mollie_voucher_category = fields.Selection(related="category_id.mollie_voucher_category", readonly=False)
     acquirer_id = fields.Many2one('payment.acquirer')

--- a/payment_mollie_official/static/description/index.html
+++ b/payment_mollie_official/static/description/index.html
@@ -223,6 +223,21 @@
 <div class="text-center text-muted" style="font-weight:400; margin-bottom:18px">
     <span style="width:73px;height: 10px;display:inline-block;border-radius: 4px;background-color: #0077ff;"> </span>
 </div>
+
+<div class="card mx-auto w-md-75">
+    <div class="card-header bg-200">
+        <h4 class="m-0">v12.0.1.6</h4>
+    </div>
+    <div class="card-body">
+        <div> <b class="text-success"> NEW </b> Added feature to extra fees(surcharge). </div>
+        <div> <b class="text-success"> NEW </b> Added support of Apple Pay for supported devices. </div>
+        <div> <b class="text-success"> NEW </b> Make mollie payments method translatable also sync translation from mollie. </div>
+        <div> <b class="text-success"> NEW </b> Filter non supported payment methods during check out (based on amount, currency and billing country). </div>
+        <div> <b class="text-warning"> UPDATE </b> Select first payment method by default when mollie method is first. </div>
+        <div> <b class="text-danger"> FIX </b> Minor bug fixes. </div>
+    </div>
+</div>
+
 <div class="card mx-auto w-md-75">
     <div class="card-header bg-200">
         <h4 class="m-0">v12.0.1.5</h4>
@@ -279,5 +294,26 @@
     </div>
     <div class="card-body">
         <div> <b class="text-success"> NEW </b> Released revamped version </div>
+    </div>
+</div>
+
+<div class="row mt-5 border text-center">
+    <div class="col-md-4 py-3" style="background-color: #0077ff;color: white;">
+        <h4 style="color: white;" class="mb-0"> Developed by <b>Applix</b></h4>
+        <div style="font-family: 'Montserrat';font-weight: 500;">
+            https://www.mollie.com/integrations/odoo
+        </div>
+    </div>
+    <div class="col-md-4 border-right py-3">
+        <h4 class="mb-0"> Contact Mollie</h4>
+        <div style="font-family: 'Montserrat';font-weight: 500;color: #0077ff;">
+            https://www.mollie.com/
+        </div>
+    </div>
+    <div class="col-md-4 py-3">
+        <h4 class="mb-0"> Contact Applix</h4>
+        <div style="font-family: 'Montserrat';font-weight: 500;color: #07f;">
+            https://www.applix.be/
+        </div>
     </div>
 </div>

--- a/payment_mollie_official/static/src/js/payment_form.js
+++ b/payment_mollie_official/static/src/js/payment_form.js
@@ -8,6 +8,7 @@ var Dialog = require('web.Dialog');
 var PaymentForm = require('payment.payment_form');
 
 var ajax = require('web.ajax');
+var weContext = require('web_editor.context');
 
 var _t = core._t;
 
@@ -34,6 +35,18 @@ PaymentForm.include({
         return this._super.apply(this, arguments).then(function () {
             return self.libPromise;
         });
+    },
+
+    /**
+     * @override
+     */
+    start: function () {
+        var self = this;
+        if (!window.ApplePaySession || !ApplePaySession.canMakePayments()) {
+            self.$('input[data-methodname="applepay"]').closest('.card-body').hide();
+            return;
+        }
+        return this._super.apply(this, arguments);
     },
 
     // ---------------------------------
@@ -113,7 +126,8 @@ PaymentForm.include({
     _loadMollieComponent: function () {
         var mollieProfileId = this.$('#o_mollie_component').data('profile_id');
         var mollieTestMode = this.$('#o_mollie_component').data('mode') === 'test';
-        this.mollieComponent = Mollie(mollieProfileId, { locale: 'en_US', testmode: mollieTestMode });
+        var lang = weContext.get().lang || 'en_US';
+        this.mollieComponent = Mollie(mollieProfileId, { locale: lang, testmode: mollieTestMode });
         this._bindMollieInputs();
     },
     /**

--- a/payment_mollie_official/views/account_payment.xml
+++ b/payment_mollie_official/views/account_payment.xml
@@ -9,7 +9,7 @@
             <xpath expr="//sheet/group[1]" position="before">
                 <field name="is_mollie_refund" invisible="1"/>
                 <field name="mollie_transecion_id" invisible="1"/>
-                <div class="alert alert-warning" attrs="{'invisible': [('is_mollie_refund', '=', False)]}">
+                <div class="alert alert-warning" role="alert" attrs="{'invisible': [('is_mollie_refund', '=', False)]}">
                     <b> Note: </b> Creating payment from here will refund the amount from mollie too.
                     <div class="float-right">
                         Maximum Amount you can refund is <b>

--- a/payment_mollie_official/views/payment_mollie_templates.xml
+++ b/payment_mollie_official/views/payment_mollie_templates.xml
@@ -36,7 +36,7 @@
         <div class="card-body" >
             <label>
                 <t t-if="acq.payment_flow == 'form'">
-                    <input type="radio" t-att-data-acquirer-id="acq.id" t-att-data-methodname="payment_method.method_id_code" t-att-data-form-payment="true" t-att-data-provider="acq.provider" name="pm_id" t-attf-value="form_{{acq.id}}" t-att-checked="acquirers_count==1 and pms_count==0 or acquirers[0] == acq"/>
+                    <input type="radio" t-att-data-acquirer-id="acq.id" t-att-data-methodname="payment_method.method_id_code" t-att-data-form-payment="true" t-att-data-provider="acq.provider" name="pm_id" t-attf-value="form_{{acq.id}}" t-att-checked="(acquirers_count==1 and pms_count==0 or acquirers[0] == acq) and payment_method_index == 0"/>
                 </t>
                 <span class="payment_option_name">
                     <t t-esc="payment_method.name"/>
@@ -44,12 +44,8 @@
                                         Test Mode
                     </div>
                 </span>
-                <t t-if="acq_extra_fees and acq_extra_fees.get(acq)">
-                    <span class="badge badge-pill badge-secondary"> +                <t t-esc="acq_extra_fees[acq]" t-options='{"widget": "monetary", "display_currency": acq_extra_fees["currency_id"]}'/>
-        Fee </span>
-                </t>
-                <t t-elif="acq.fees_active">
-                    <small class="text-muted">(Some fees may apply)</small>
+                <t t-if="acq.fees_active">
+                    <small class="text-muted">(some fees may apply)</small>
                 </t>
             </label>
             <ul class="float-right list-inline payment_icon_list">

--- a/payment_mollie_official/views/payment_views.xml
+++ b/payment_mollie_official/views/payment_views.xml
@@ -23,7 +23,7 @@
             <page name="acquirer_credentials" position="after">
                 <page string="Mollie Payment Methods" attrs="{'invisible': [('provider', '!=', 'mollie')]}">
                     <field name="mollie_methods_ids" >
-                        <tree create="0" editable="bottom">
+                        <tree create="0">
                             <field name="sequence" widget="handle"/>
                             <field name="name" />
                             <field name="method_id_code"/>
@@ -38,18 +38,54 @@
                             <field name="supports_payment_api" invisible="1"/>
                             <field name="payment_issuer_ids" widget="many2many_tags" invisible="1"/>
                         </tree>
+                        <form>
+                            <div class="oe_title">
+                                <h1>
+                                    <field name="name" placeholder="Name"/>
+                                </h1>
+                                <group>
+                                    <field name="method_id_code" readonly="1"/>
+                                </group>
+                            </div>
+                            <notebook>
+                                <page name="config" string="Configuration">
+                                    <group>
+                                        <group>
+                                            <field name="active" invisible="1"/>
+                                            <field name="active_on_shop" widget="boolean_toggle"/>
+                                            <field name="journal_id"/>
+                                        </group>
+                                        <group>
+                                            <field name="payment_icon_ids" widget="many2many_tags"/>
+                                            <field name="country_ids" widget="many2many_tags"/>
+                                        </group>
+                                    </group>
+                                </page>
+                                <page string="Fees" name="method_fees" attrs="{'invisible': [('parent.fees_active', '=', False)]}">
+                                    <group>
+                                        <group name="method_payment_fees">
+                                            <field name="fees_active"/>
+                                            <field name="fees_dom_fixed" attrs="{'invisible': [('fees_active', '=', False)]}"/>
+                                            <field name="fees_dom_var" attrs="{'invisible': [('fees_active', '=', False)]}"/>
+                                            <field name="fees_int_fixed" attrs="{'invisible': [('fees_active', '=', False)]}"/>
+                                            <field name="fees_int_var" attrs="{'invisible': [('fees_active', '=', False)]}"/>
+                                        </group>
+                                    </group>
+                                </page>
+                                <page string="Voucher Configuration" name="voucher_config" attrs="{'invisible': [('method_id_code', '!=', 'voucher')]}">
+                                    <field name="mollie_voucher_ids">
+                                        <tree editable="bottom">
+                                            <field name="category_id"/>
+                                            <field name="mollie_voucher_category"/>
+                                        </tree>
+                                    </field>
+                                </page>
+                            </notebook>
+                        </form>
                     </field>
                     <button type="object" name="action_mollie_sync_methods" class="btn btn-link">
                         <span><i class="fa fa-refresh"></i> Sync payment methods </span>
                     </button>
-                </page>
-                <page string="Voucher Configuration" attrs="{'invisible': [('mollie_voucher_enabled', '=', False)]}">
-                    <field name="mollie_voucher_ids">
-                        <tree editable="bottom">
-                            <field name="category_id"/>
-                            <field name="mollie_voucher_category"/>
-                        </tree>
-                    </field>
                 </page>
             </page>
         </field>


### PR DESCRIPTION
    - Added feature to extra fees(surcharge).
    - Added support of Apple Pay for supported devices.
    - Make mollie payments method translatable also sync translation via mollie method API.
    - Filter non supported payment methods during check out (based on amount, currency and billing country).
    - Select first payment method by default when mollie method is first.
    - Minor bug fixes.