### PR TITLE
Release new version v13.0.1.7

### DIFF
--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Payments',
-    'version': '13.0.1.6',
+    'version': '13.0.1.7',
     'category': 'eCommerce',
     'license': 'LGPL-3',
     'author': 'Mollie',

--- a/payment_mollie_official/models/mollie_method.py
+++ b/payment_mollie_official/models/mollie_method.py
@@ -12,10 +12,10 @@ class MolliePaymentMethod(models.Model):
     _description = 'Mollie payment method'
     _order = "sequence, id"
 
-    name = fields.Char()
+    name = fields.Char(translate=True)
     sequence = fields.Integer()
     parent_id = fields.Many2one('payment.acquirer')  # This will be always mollie
-    method_id_code = fields.Char()
+    method_id_code = fields.Char(string="Method code")
     payment_icon_ids = fields.Many2many('payment.icon', string='Supported Payment Icons')
     active = fields.Boolean(default=True)
     active_on_shop = fields.Boolean(string="Enabled on shop", default=True)
@@ -31,3 +31,11 @@ class MolliePaymentMethod(models.Model):
     payment_issuer_ids = fields.Many2many('mollie.payment.method.issuer', string='Issuers')
 
     country_ids = fields.Many2many('res.country', string='Country Availability')
+
+    fees_active = fields.Boolean('Add Extra Fees')
+    fees_dom_fixed = fields.Float('Fixed domestic fees')
+    fees_dom_var = fields.Float('Variable domestic fees (in percents)')
+    fees_int_fixed = fields.Float('Fixed international fees')
+    fees_int_var = fields.Float('Variable international fees (in percents)')
+
+    mollie_voucher_ids = fields.One2many('mollie.voucher.line', 'method_id', string='Mollie Voucher Config')

--- a/payment_mollie_official/models/payment_acquirer.py
+++ b/payment_mollie_official/models/payment_acquirer.py
@@ -27,6 +27,41 @@ class PaymentAcquirerMollie(models.Model):
     mollie_voucher_ids = fields.One2many('mollie.voucher.line', 'acquirer_id', string='Mollie Voucher Config')
     mollie_voucher_enabled = fields.Boolean(compute="_compute_mollie_voucher_enabled")
 
+    def _get_feature_support(self):
+        res = super(PaymentAcquirerMollie, self)._get_feature_support()
+        res['fees'].append('mollie')
+        return res
+
+    def mollie_compute_fees(self, amount, currency_id, country_id):
+        fees = {}
+
+        if self.fees_active:
+            for method in self.mollie_methods_ids:
+                if method.fees_active:
+                    fees[method.method_id_code] = self._mollie_compute_record_fees(amount, method, country_id)  # method fees
+                else:
+                    fees[method.method_id_code] = self._mollie_compute_record_fees(amount, self, country_id)  # global fees
+
+        # TO-DO: Find alternative way for this. Currently, this is simpleset solution as
+        # this method is used at shop, order portal and invoice portal. The full dictionary
+        # is used in payment acquirer list but we send usual fees when we get request from
+        # particular payment method.
+        if request and request.params.get('paymentmethod'):
+            fees = fees.get(request.params.get('paymentmethod'), 0.0)
+
+        return fees
+
+    def _mollie_compute_record_fees(self, amount, record, country_id):
+        country = self.env['res.country'].browse(country_id)
+        if country and self.company_id.sudo().country_id.id == country.id:
+            percentage = record.fees_dom_var
+            fixed = record.fees_dom_fixed
+        else:
+            percentage = record.fees_int_var
+            fixed = record.fees_int_fixed
+        fees = (percentage / 100.0 * amount + fixed) / (1 - percentage / 100.0)
+        return fees
+
     @api.depends('mollie_methods_ids')
     def _compute_mollie_voucher_enabled(self):
         for acquirer in self:
@@ -39,6 +74,39 @@ class PaymentAcquirerMollie(models.Model):
         methods = self._api_mollie_get_active_payment_methods()
         if methods:
             self._sync_mollie_methods(methods)
+            self._create_method_translations(methods)
+
+    def _create_method_translations(self, english_methods):
+        IrTranslation = self.env['ir.translation']
+        supported_locale = self._mollie_get_supported_locale()
+        supported_locale.remove('en_US')  # en_US is default
+        active_langs = self.env['res.lang'].search([('code', 'in', supported_locale)])
+        mollie_methods = self.mollie_methods_ids
+
+        for lang in active_langs:
+            existing_trans = self.env['ir.translation'].search([('name', '=', 'mollie.payment.method,name'), ('lang', '=', lang.code)])
+            translated_method_ids = existing_trans.mapped('res_id')
+            method_to_translate = []
+            for method in mollie_methods:
+                if method.id not in translated_method_ids:
+                    method_to_translate.append(method.id)
+
+            # This will avoid unnessesorry network calls
+            if method_to_translate:
+                methods_data = self._api_mollie_get_active_payment_methods(extra_params={'locale': lang.code})
+                for method_id in method_to_translate:
+                    mollie_method = mollie_methods.filtered(lambda m: m.id == method_id)
+                    translated_value = methods_data.get(mollie_method.method_id_code, {}).get('description')
+                    if translated_value:
+                        IrTranslation.create({
+                            'type': 'model',
+                            'name': 'mollie.payment.method,name',
+                            'lang': lang.code,
+                            'res_id': method_id,
+                            'src': mollie_method.name,
+                            'value': translated_value,
+                            'state': 'translated',
+                        })
 
     def _sync_mollie_methods(self, methods_dict):
 
@@ -120,14 +188,19 @@ class PaymentAcquirerMollie(models.Model):
             methods = methods.filtered(lambda m: m.method_id_code != 'creditcard')
 
         # Hide methods if order amount is higher then method limits
-        remove_voucher_method = True
+        remove_voucher_method, extra_params = True, {}
         if order and order._name == 'sale.order':
             methods = methods.filtered(lambda m: order.amount_total >= m.min_amount and (order.amount_total <= m.max_amount or not m.max_amount))
             remove_voucher_method = not any(map(lambda p: p._get_mollie_voucher_category(), order.mapped('order_line.product_id.product_tmpl_id')))
+            extra_params['amount'] = {'value': "%.2f" % order.amount_total, 'currency': order.currency_id.name}
+            if order.partner_invoice_id.country_id:
+                extra_params['billingCountry'] = order.partner_invoice_id.country_id.code
         if order and order._name == 'account.move':
             methods = methods.filtered(lambda m: order.amount_residual >= m.min_amount and (order.amount_residual <= m.max_amount or not m.max_amount))
             remove_voucher_method = not any(map(lambda p: p._get_mollie_voucher_category(), order.mapped('invoice_line_ids.product_id.product_tmpl_id')))
-
+            extra_params['amount'] = {'value': "%.2f" % order.amount_residual, 'currency': order.currency_id.name}
+            if order.partner_id.country_id:
+                extra_params['billingCountry'] = order.partner_id.country_id.code
         if remove_voucher_method:
             methods = methods.filtered(lambda m: m.method_id_code != 'voucher')
 
@@ -140,6 +213,10 @@ class PaymentAcquirerMollie(models.Model):
             country_code = request.session.geoip and request.session.geoip.get('country_code') or False
             if country_code:
                 methods = methods.filtered(lambda m: not m.country_ids or country_code in m.country_ids.mapped('code'))
+
+        # Hide methods if mollie does not supports them
+        suppported_methods = self.sudo()._api_mollie_get_active_payment_methods(extra_params=extra_params)   # sudo as public user do not have access
+        methods = methods.filtered(lambda m: m.method_id_code in suppported_methods.keys())
 
         return methods
 
@@ -207,7 +284,7 @@ class PaymentAcquirerMollie(models.Model):
             'method': transaction.mollie_payment_method,
             'amount': {
                 'currency': transaction.currency_id.name,
-                'value': "%.2f" % transaction.amount
+                'value': "%.2f" % (transaction.amount + transaction.fees)
             },
 
             'billingAddress': order_source.partner_id._prepare_mollie_address(),
@@ -255,7 +332,7 @@ class PaymentAcquirerMollie(models.Model):
             'method': transaction.mollie_payment_method,
             'amount': {
                 'currency': transaction.currency_id.name,
-                'value': "%.2f" % transaction.amount
+                'value': "%.2f" % (transaction.amount + transaction.fees)
             },
             'description': transaction.reference,
 
@@ -355,12 +432,13 @@ class PaymentAcquirerMollie(models.Model):
         mollie_client = self._api_mollie_get_client()
         return mollie_client.orders.get(tx_id, embed="payments")
 
-    def _api_mollie_get_active_payment_methods(self, api_type=None):
+    def _api_mollie_get_active_payment_methods(self, api_type=None, extra_params={}):
         result = {}
 
         mollie_client = self._api_mollie_get_client()
-        order_methods = mollie_client.methods.list(resource="orders", include='issuers')
-        payment_methods = mollie_client.methods.list()
+        params = {'include': 'issuers', 'includeWallets': 'applepay', **extra_params}
+        order_methods = mollie_client.methods.list(resource="orders", **params)
+        payment_methods = mollie_client.methods.list(**params)
 
         # Order api will always have more methods then payment api
         if order_methods.get('count'):
@@ -400,7 +478,33 @@ class PaymentAcquirerMollie(models.Model):
         if order._name == "account.move":
             order_lines = order.invoice_line_ids.filtered(lambda l: not l.display_type)  # ignore notes and section lines
             lines = self._mollie_prepare_invoice_lines(order_lines, transaction)
+        if transaction.fees:    # Fees or Surcharge (if configured)
+            fees_line = self._mollie_prepare_fees_line(transaction)
+            lines.append(fees_line)
         return lines
+
+    def _mollie_prepare_fees_line(self, transaction):
+        return {
+            'name': _('Acquirer Fees'),
+            'type': 'surcharge',
+            'metadata': {
+                "type": 'surcharge'
+            },
+            'quantity': 1,
+            'unitPrice': {
+                'currency': transaction.currency_id.name,
+                'value': "%.2f" % transaction.fees
+            },
+            'totalAmount': {
+                'currency': transaction.currency_id.name,
+                'value': "%.2f" % transaction.fees
+            },
+            'vatRate': "%.2f" % 0,
+            'vatAmount': {
+                'currency': transaction.currency_id.name,
+                'value': "%.2f" % 0
+            }
+        }
 
     def _mollie_prepare_so_lines(self, lines, transaction):
         result = []
@@ -509,14 +613,17 @@ class PaymentAcquirerMollie(models.Model):
 
     def _mollie_user_locale(self):
         user_lang = self.env.context.get('lang')
-        supported_locale = [
+        supported_locale = self._mollie_get_supported_locale()
+        return user_lang if user_lang in supported_locale else 'en_US'
+
+    def _mollie_get_supported_locale(self):
+        return [
             'en_US', 'nl_NL', 'nl_BE', 'fr_FR',
             'fr_BE', 'de_DE', 'de_AT', 'de_CH',
             'es_ES', 'ca_ES', 'pt_PT', 'it_IT',
             'nb_NO', 'sv_SE', 'fi_FI', 'da_DK',
             'is_IS', 'hu_HU', 'pl_PL', 'lv_LV',
             'lt_LT']
-        return user_lang if user_lang in supported_locale else 'en_US'
 
     def _mollie_redirect_url(self, tx_id):
         base_url = self.get_base_url()

--- a/payment_mollie_official/models/payment_transection.py
+++ b/payment_mollie_official/models/payment_transection.py
@@ -35,6 +35,10 @@ class PaymentTransaction(models.Model):
         if request and request.params.get('mollie_issuer'):
             create_vals['mollie_payment_issuer'] = request.params.get('mollie_issuer')
 
+        if vals.get('fees') and isinstance(vals['fees'], dict):
+            payment_method = create_vals.get('mollie_payment_method')
+            vals['fees'] = vals['fees'].get(payment_method, 0)
+
         return create_vals
 
     def _mollie_form_get_tx_from_data(self, data):
@@ -59,7 +63,7 @@ class PaymentTransaction(models.Model):
 
         # Check what transection is with same amount
         amount = data.get('amount')
-        if amount and float_compare(float(amount.get('value', '0.0')), self.amount, 2) != 0:
+        if amount and float_compare(float(amount.get('value', '0.0')), self.amount + self.fees, 2) != 0:
             invalid_parameters.append(('Amount', amount.get('value'), '%.2f' % self.amount))
         if amount.get('currency') != self.currency_id.name:
             invalid_parameters.append(('Currency', data.get('currency'), self.currency_id.name))

--- a/payment_mollie_official/models/voucher_lines.py
+++ b/payment_mollie_official/models/voucher_lines.py
@@ -9,7 +9,15 @@ _logger = logging.getLogger(__name__)
 
 class MollieVoucherLines(models.Model):
     _name = 'mollie.voucher.line'
+    _description = 'Mollie Voucher Line'
 
+    def _default_voucher_category(self):
+        """ We moved field from acquirer to method line.
+            This will migrate existing lines to voucher method.
+        """
+        return self.env['mollie.payment.method'].with_context(active_test=False).search([('method_id_code', '=', 'voucher')], limit=1)
+
+    method_id = fields.Many2one('mollie.payment.method', default=_default_voucher_category)
     category_id = fields.Many2one('product.category')
     mollie_voucher_category = fields.Selection(related="category_id.mollie_voucher_category", readonly=False)
     acquirer_id = fields.Many2one('payment.acquirer')

--- a/payment_mollie_official/static/description/index.html
+++ b/payment_mollie_official/static/description/index.html
@@ -223,6 +223,22 @@
 <div class="text-center text-muted" style="font-weight:400; margin-bottom:18px">
     <span style="width:73px;height: 10px;display:inline-block;border-radius: 4px;background-color: #0077ff;"> </span>
 </div>
+
+<div class="card mx-auto w-md-75">
+    <div class="card-header bg-200">
+        <h4 class="m-0">v13.0.1.7</h4>
+    </div>
+    <div class="card-body">
+        <div> <b class="text-success"> NEW </b> Added feature to extra fees(surcharge). </div>
+        <div> <b class="text-success"> NEW </b> Added support of Apple Pay for supported devices. </div>
+        <div> <b class="text-success"> NEW </b> Make mollie payments method translatable also sync translation from mollie. </div>
+        <div> <b class="text-success"> NEW </b> Filter non supported payment methods during check out (based on amount, currency and billing country). </div>
+        <div> <b class="text-warning"> UPDATE </b> Select first payment method by default when mollie method is first. </div>
+        <div> <b class="text-danger"> FIX </b> Fixed SEPA payment module view conflict. </div>
+        <div> <b class="text-danger"> FIX </b> Minor bug fixes. </div>
+    </div>
+</div>
+
 <div class="card mx-auto w-md-75">
     <div class="card-header bg-200">
         <h4 class="m-0">v13.0.1.6</h4>
@@ -291,5 +307,26 @@
         <div> <b class="text-success"> NEW </b> Added inline issuer support </div>
         <div> <b class="text-success"> NEW </b> Separate/Common account journal for payment methods </div>
         <div> <b class="text-success"> NEW </b> Enable/Disable payment methods for shop </div>
+    </div>
+</div>
+
+<div class="row mt-5 border text-center">
+    <div class="col-md-4 py-3" style="background-color: #0077ff;color: white;">
+        <h4 style="color: white;" class="mb-0"> Developed by <b>Applix</b></h4>
+        <div style="font-family: 'Montserrat';font-weight: 500;">
+            https://www.mollie.com/integrations/odoo
+        </div>
+    </div>
+    <div class="col-md-4 border-right py-3">
+        <h4 class="mb-0"> Contact Mollie</h4>
+        <div style="font-family: 'Montserrat';font-weight: 500;color: #0077ff;">
+            https://www.mollie.com/
+        </div>
+    </div>
+    <div class="col-md-4 py-3">
+        <h4 class="mb-0"> Contact Applix</h4>
+        <div style="font-family: 'Montserrat';font-weight: 500;color: #07f;">
+            https://www.applix.be/
+        </div>
     </div>
 </div>

--- a/payment_mollie_official/static/src/js/payment_form.js
+++ b/payment_mollie_official/static/src/js/payment_form.js
@@ -35,6 +35,20 @@ publicWidget.registry.PaymentForm.include({
         });
     },
 
+    /**
+     * @override
+     */
+    start: function () {
+        var self = this;
+        return this._super.apply(this, arguments).then(function () {
+            // Hide the option if Apple Pay is not available
+            if (!window.ApplePaySession || !ApplePaySession.canMakePayments()) {
+                self.$('input[data-methodname="applepay"]').closest('.o_payment_acquirer_select').hide();
+                return;
+            }
+        });
+    },
+
     // ---------------------------------
     // Existing Overridden methods
     // ---------------------------------
@@ -112,7 +126,15 @@ publicWidget.registry.PaymentForm.include({
     _loadMollieComponent: function () {
         var mollieProfileId = this.$('#o_mollie_component').data('profile_id');
         var mollieTestMode = this.$('#o_mollie_component').data('mode') === 'test';
-        this.mollieComponent = Mollie(mollieProfileId, { locale: 'en_US', testmode: mollieTestMode });
+
+        var context;
+        this.trigger_up('context_get', {
+            callback: function (ctx) {
+                context = ctx;
+            },
+        });
+        var lang = context.lang || 'en_US';
+        this.mollieComponent = Mollie(mollieProfileId, { locale: lang, testmode: mollieTestMode });
         this._bindMollieInputs();
     },
     /**

--- a/payment_mollie_official/views/account_payment.xml
+++ b/payment_mollie_official/views/account_payment.xml
@@ -9,7 +9,7 @@
             <field name="id" position="after">
                 <field name="is_mollie_refund" invisible="1"/>
                 <field name="mollie_transecion_id" invisible="1"/>
-                <div class="alert alert-warning" attrs="{'invisible': [('is_mollie_refund', '=', False)]}">
+                <div class="alert alert-warning" role="alert" attrs="{'invisible': [('is_mollie_refund', '=', False)]}">
                     <b> Note: </b> Creating payment from here will refund the amount from mollie too.
                     <div class="float-right">
                         Maximum Amount you can refund is <b>

--- a/payment_mollie_official/views/payment_mollie_templates.xml
+++ b/payment_mollie_official/views/payment_mollie_templates.xml
@@ -36,7 +36,7 @@
         <div class="card-body o_payment_acquirer_select" >
             <label>
                 <t t-if="acq.payment_flow == 'form'">
-                    <input type="radio" t-att-data-acquirer-id="acq.id" t-att-data-methodname="payment_method.method_id_code" t-att-data-form-payment="true" t-att-data-provider="acq.provider" name="pm_id" t-attf-value="form_{{acq.id}}" t-att-checked="acquirers_count==1 and pms_count==0 or acquirers[0] == acq"/>
+                    <input type="radio" t-att-data-acquirer-id="acq.id" t-att-data-methodname="payment_method.method_id_code" t-att-data-form-payment="true" t-att-data-provider="acq.provider" name="pm_id" t-attf-value="form_{{acq.id}}" t-att-checked="(acquirers_count==1 and pms_count==0 or acquirers[0] == acq) and payment_method_index == 0"/>
                 </t>
                 <span class="payment_option_name">
                     <t t-esc="payment_method.name"/>
@@ -44,12 +44,8 @@
                             Test Mode
                     </div>
                 </span>
-                <t t-if="acq_extra_fees and acq_extra_fees.get(acq)">
-                    <span class="badge badge-pill badge-secondary"> +                <t t-esc="acq_extra_fees[acq]" t-options='{"widget": "monetary", "display_currency": acq_extra_fees["currency_id"]}'/>
-        Fee </span>
-                </t>
-                <t t-elif="acq.fees_active">
-                    <small class="text-muted">(Some fees may apply)</small>
+                <t t-if="acq_extra_fees and acq_extra_fees.get(acq) and acq_extra_fees[acq].get(payment_method.method_id_code)">
+                    <span class="badge badge-pill badge-secondary"> + <t t-esc="acq_extra_fees[acq][payment_method.method_id_code]" t-options='{"widget": "monetary", "display_currency": acq_extra_fees["currency_id"]}'/> Fee </span>
                 </t>
             </label>
             <ul class="float-right list-inline payment_icon_list">

--- a/payment_mollie_official/views/payment_views.xml
+++ b/payment_mollie_official/views/payment_views.xml
@@ -4,6 +4,7 @@
         <field name="name">payment.acquirer.form.inherit</field>
         <field name="model">payment.acquirer</field>
         <field name="inherit_id" ref="payment.acquirer_form"/>
+        <field name="priority">20</field>
         <field name="arch" type="xml">
             <xpath expr='//group[@name="acquirer"]' position='inside'>
                 <group attrs="{'invisible': [('provider', '!=', 'mollie')]}">
@@ -12,7 +13,7 @@
                     <field name="mollie_profile_id" attrs="{'required':[ ('provider', '=', 'mollie'), ('state', '=', 'enabled')]}" password="True"/>
                     <field name="mollie_voucher_enabled" invisible="1"/>
                     <label string=" " for="mollie_profile_id"> </label>
-                    <small class="text-muted"> Credit card option will not be displayed without profile ID.
+                    <small class="text-muted oe_edit_only"> Credit card option will not be displayed without profile ID.
                         <br/>
                         <b><a href="https://www.mollie.com/dashboard/developers/api-keys" target="_new"> Get your API keys <i class="fa fa-arrow-right"> </i> </a></b>
                         <br/>
@@ -23,7 +24,7 @@
             <page name="acquirer_credentials" position="after">
                 <page string="Mollie Payment Methods" attrs="{'invisible': [('provider', '!=', 'mollie')]}">
                     <field name="mollie_methods_ids" >
-                        <tree create="0" editable="bottom">
+                        <tree create="0">
                             <field name="sequence" widget="handle"/>
                             <field name="name" />
                             <field name="method_id_code" optional="hide"/>
@@ -38,18 +39,54 @@
                             <field name="supports_payment_api" invisible="1"/>
                             <field name="payment_issuer_ids" widget="many2many_tags" invisible="1"/>
                         </tree>
+                        <form>
+                            <div class="oe_title">
+                                <h1>
+                                    <field name="name" placeholder="Name"/>
+                                </h1>
+                                <group>
+                                    <field name="method_id_code" readonly="1"/>
+                                </group>
+                            </div>
+                            <notebook>
+                                <page name="config" string="Configuration">
+                                    <group>
+                                        <group>
+                                            <field name="active" invisible="1"/>
+                                            <field name="active_on_shop" widget="boolean_toggle"/>
+                                            <field name="journal_id"/>
+                                        </group>
+                                        <group>
+                                            <field name="payment_icon_ids" widget="many2many_tags"/>
+                                            <field name="country_ids" widget="many2many_tags"/>
+                                        </group>
+                                    </group>
+                                </page>
+                                <page string="Fees" name="method_fees" attrs="{'invisible': [('parent.fees_active', '=', False)]}">
+                                    <group>
+                                        <group name="method_payment_fees">
+                                            <field name="fees_active"/>
+                                            <field name="fees_dom_fixed" attrs="{'invisible': [('fees_active', '=', False)]}"/>
+                                            <field name="fees_dom_var" attrs="{'invisible': [('fees_active', '=', False)]}"/>
+                                            <field name="fees_int_fixed" attrs="{'invisible': [('fees_active', '=', False)]}"/>
+                                            <field name="fees_int_var" attrs="{'invisible': [('fees_active', '=', False)]}"/>
+                                        </group>
+                                    </group>
+                                </page>
+                                <page string="Voucher Configuration" name="voucher_config" attrs="{'invisible': [('method_id_code', '!=', 'voucher')]}">
+                                    <field name="mollie_voucher_ids">
+                                        <tree editable="bottom">
+                                            <field name="category_id"/>
+                                            <field name="mollie_voucher_category"/>
+                                        </tree>
+                                    </field>
+                                </page>
+                            </notebook>
+                        </form>
                     </field>
                     <button type="object" name="action_mollie_sync_methods" class="btn btn-link">
                         <span><i class="fa fa-refresh"></i> Sync payment methods </span>
                     </button>
-                </page>
-                <page string="Voucher Configuration" attrs="{'invisible': [('mollie_voucher_enabled', '=', False)]}">
-                    <field name="mollie_voucher_ids">
-                        <tree editable="bottom">
-                            <field name="category_id"/>
-                            <field name="mollie_voucher_category"/>
-                        </tree>
-                    </field>
                 </page>
             </page>
         </field>


### PR DESCRIPTION
    - Added feature to extra fees(surcharge).
    - Added support of Apple Pay for supported devices.
    - Make mollie payments method translatable also sync translation via mollie method API.
    - Filter non supported payment methods during check out (based on amount, currency and billing country).
    - Select first payment method by default when mollie method is first.
    - Fixed SEPA payment module view conflict.
    - Minor bug fixes.