### PR TITLE
[FIX] payment_mollie_official: Remove extraneous slash from payments URL

### DIFF
--- a/payment_mollie_official/models/mollie.py
+++ b/payment_mollie_official/models/mollie.py
@@ -129,7 +129,7 @@ class TxMollie(models.Model):
 
         _logger.info('Validated transfer payment for tx %s: set as pending' % (reference))
         mollie_api_key = acquirer._get_mollie_api_keys(acquirer.environment)['mollie_api_key']
-        url = "%s/payments" % (acquirer._get_mollie_urls(acquirer.environment)['mollie_form_url'])
+        url = "%spayments" % (acquirer._get_mollie_urls(acquirer.environment)['mollie_form_url'])
 
         payload = {
             "id": transactionId


### PR DESCRIPTION
Previously, when https://api.mollie.nl/v1//payments (note the double
slash) was requested, a 404 response was returned. When there is only a
single slash, everything works fine.

This bad behaviour started occurring on 18 or 19 January 2022.