### PR TITLE
[FIX] payment_mollie_official: add missing hooks

### DIFF
--- a/payment_mollie_official/__init__.py
+++ b/payment_mollie_official/__init__.py
@@ -2,3 +2,8 @@
 
 from . import models
 from . import controllers
+from odoo.addons.payment.models.payment_acquirer import create_missing_journal_for_acquirers
+from odoo.addons.payment import reset_payment_provider
+
+def uninstall_hook(cr, registry):
+    reset_payment_provider(cr, registry, 'mollie')

--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Payments',
-    'version': '14.0.0.10',
+    'version': '14.0.0.11',
     'category': 'eCommerce',
     'license': 'LGPL-3',
     'author': 'Mollie',
@@ -36,4 +36,6 @@
     'images': [
         'static/description/cover.png',
     ],
+    'post_init_hook': 'create_missing_journal_for_acquirers',
+    'uninstall_hook': 'uninstall_hook',
 }


### PR DESCRIPTION
This commits adds

- 'post_init_hook': required to create payment journal
- 'uninstall_hook': required to disable payment acquirer