### PR TITLE
[FIX] Remove deprecated xmlDependencies

### DIFF
--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Payments Extended',
-    'version': '16.0.0.1',
+    'version': '16.0.0.2',
     'category': 'eCommerce',
     'license': 'LGPL-3',
     'author': 'Mollie',
@@ -32,6 +32,7 @@
             'payment_mollie_official/static/src/js/payment_form.js',
             'payment_mollie_official/static/src/js/qr_dialog.js',
             'payment_mollie_official/static/src/scss/payment_form.scss',
+            'payment_mollie_official/static/src/xml/dialog.xml',
         ]
     },
 

--- a/payment_mollie_official/static/src/js/qr_dialog.js
+++ b/payment_mollie_official/static/src/js/qr_dialog.js
@@ -10,7 +10,6 @@ var qweb = core.qweb;
 
 var QrModel = Dialog.extend({
     template: 'mollie.qr.dialog',
-    xmlDependencies: (Dialog.prototype.xmlDependencies || []).concat(['/payment_mollie_official/static/src/xml/dialog.xml']),
     events: {
         "click .dr_continue_checkout": '_onClickContinue',
     },


### PR DESCRIPTION
The `mollie.qr.dialog` widget uses a deprecated method for declaring XML assets (removed in [this](https://github.com/odoo/odoo/commit/5410b7c238f211ced2519e53afc99c8468e1f527) Odoo 16 commit.)
As a result the dialog would cause a "template not found" error on payment options where QR payment was enabled.

This pull request fixes it by moving the asset declaration into __manifest__.py under assets_frontend, as Odoo did to all of its xmlDependencies ([cf.](https://github.com/odoo/odoo/commit/39ea7a1fab257ab46a8faf97eea75cc37f8c43e5))