### PR TITLE
[FIX] mollie_pos_terminal: js error when clicking on 'back' during payment

### DIFF
--- a/mollie_pos_terminal/static/src/js/models.js
+++ b/mollie_pos_terminal/static/src/js/models.js
@@ -2,8 +2,6 @@ odoo.define('mollie_pos_terminal.models', function (require) {
     var models = require('point_of_sale.models');
     var PaymentMollie = require('mollie_pos_terminal.payment');
 
-    debugger;
-
     models.register_payment_method('mollie', PaymentMollie);
     models.load_fields('pos.payment.method', 'mollie_pos_terminal_id');
 

--- a/mollie_pos_terminal/static/src/js/payment_mollie.js
+++ b/mollie_pos_terminal/static/src/js/payment_mollie.js
@@ -93,7 +93,7 @@ const PaymentMollie = PaymentInterface.extend({
                 line.set_payment_status('retry');
             }
         });
-        return false;
+        return Promise.resolve();
     },
 
     close: function () {


### PR DESCRIPTION
Instead of opening the popup 'Cancel mollie payment' an error is thrown, breaking the UI.

js error:
`TypeError: line.payment_method.payment_terminal.send_payment_cancel(...).finally is not a function`