### PR TITLE
[IMP] Add pyproject.toml files

### DIFF
--- a/mollie_balance_sync/__manifest__.py
+++ b/mollie_balance_sync/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Balance Sync',
-    'version': '18.0.0.2',
+    'version': '18.0.0.2.0',
     'description': '',
     'summary': 'This module sync balances from mollie',
     'author': 'Mollie',

--- a/mollie_balance_sync/__manifest__.py
+++ b/mollie_balance_sync/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Balance Sync',
-    'version': '18.0.0.3',
+    'version': '18.0.0.3.0',
     'description': '',
     'summary': 'This module sync balances from mollie',
     'author': 'Mollie',

--- a/mollie_balance_sync/pyproject.toml
+++ b/mollie_balance_sync/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/mollie_pos_terminal/__manifest__.py
+++ b/mollie_pos_terminal/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Mollie Pos Terminal',
-    'version': '18.0.0.6',
+    'version': '18.0.0.6.0',
     'description': '',
     'summary': 'Connect your pos with mollie terminal',
     'author': 'Mollie',

--- a/mollie_pos_terminal/__manifest__.py
+++ b/mollie_pos_terminal/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Mollie Pos Terminal',
-    'version': '18.0.0.8',
+    'version': '18.0.0.8.0',
     'description': '',
     'summary': 'Connect your pos with mollie terminal',
     'author': 'Mollie',

--- a/mollie_pos_terminal/pyproject.toml
+++ b/mollie_pos_terminal/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/mollie_sales_invoice_terminal_payments/__manifest__.py
+++ b/mollie_sales_invoice_terminal_payments/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Direct Payments Terminal',
-    'version': '18.0.0.5',
+    'version': '18.0.0.5.0',
     'description': '',
     'summary': 'Pay Sales orders & Invoices seamlessly via Mollie Terminal',
     'author': 'Mollie',

--- a/mollie_sales_invoice_terminal_payments/pyproject.toml
+++ b/mollie_sales_invoice_terminal_payments/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Payments Extended',
-    'version': '18.0.0.3',
+    'version': '18.0.0.3.0',
     'category': 'eCommerce',
     'license': 'LGPL-3',
     'author': 'Mollie',

--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Payments Extended',
-    'version': '18.0.0.5',
+    'version': '18.0.0.5.0',
     'category': 'eCommerce',
     'license': 'LGPL-3',
     'author': 'Mollie',

--- a/payment_mollie_official/pyproject.toml
+++ b/payment_mollie_official/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/payment_mollie_official_fees/__manifest__.py
+++ b/payment_mollie_official_fees/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Fees for Mollie Payments Extended',
-    'version': '18.0.0.0',
+    'version': '18.0.0.0.0',
     'category': 'eCommerce',
     'license': 'LGPL-3',
     'author': 'Mollie',

--- a/payment_mollie_official_fees/pyproject.toml
+++ b/payment_mollie_official_fees/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"


### PR DESCRIPTION
To support PEP 621 and to be able to install each module separately with python `pip` command, add a pyproject.toml in each module root.

That one will rely on `whool` build backend to package individual Odoo addons in an installable one.

https://pypi.org/project/whool/

The module versioning should adopt the 'A.B.X.Y.Z' where A and B are for Odoo version and X, Y and Z for module major, minor and patch ones.


NOTE: this will not harm at all any current install of modules .