### PR TITLE
[IMP] mollie_pos_terminal: Remove view warning with `fa` class missing title

### DIFF
--- a/mollie_pos_terminal/wizard/mollie_sync_terminal.xml
+++ b/mollie_pos_terminal/wizard/mollie_sync_terminal.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <form>
                 <div class="text-center" invisible="mollie_terminal_api_key">
-                    <i class="fa fa-exclamation-triangle d-inline-block text-danger rounded-circle" style="background: #ffe3e3;padding: 15px;font-size: 20px;" aria-hidden="true"></i>
+                    <i class="fa fa-exclamation-triangle d-inline-block text-danger rounded-circle" style="background: #ffe3e3;padding: 15px;font-size: 20px;" title="API Key not set" aria-hidden="true"></i>
                     <h3>Api key is not set.</h3>
                     <p>Please set api key from pos configuration.</p>
                 </div>


### PR DESCRIPTION
Warning in logs:

![image](https://github.com/user-attachments/assets/0d13d67a-fbd8-40a6-b5f3-cb0b7f20d5d7)
