### PR TITLE
[FIX] mollie_pos_terminal: crash on duplicate/late payment status resolution

### DIFF
--- a/mollie_pos_terminal/static/src/app/utils/payment/payment_mollie.js
+++ b/mollie_pos_terminal/static/src/app/utils/payment/payment_mollie.js
@@ -163,6 +163,9 @@ export class PaymentMollie extends PaymentInterface {
     async handleMollieStatusResponse() {
 
         const line = this.pending_mollie_line();
+        if (!line) {
+            return;
+        }
         const paymentStatus = await this.env.services.orm.silent
             .call('mollie.pos.terminal.payments', 'get_mollie_payment_status', [
             ], {
@@ -185,6 +188,9 @@ export class PaymentMollie extends PaymentInterface {
 
     _resolvePaymentStatus(state) {
         const line = this.pending_mollie_line();
+        if (!line) {
+            return;
+        }
         const resolver = this.paymentLineResolvers?.[line.uuid];
         if (resolver) {
             resolver(state);


### PR DESCRIPTION
## Problem

On a POS with multiple Mollie terminals configured on the same `pos.config` (e.g. two Bancontact terminals), a payment can trigger two near-simultaneous `get_mollie_payment_status` calls for the same payment line (observed on a customer's production instance: two calls 1ms apart, right after a successful payment).

The first call resolves the payment line normally. By the time the second call reaches `_resolvePaymentStatus`, `pending_mollie_line()` returns `undefined` (`getPendingPaymentLine` in Odoo core filters out lines where `isDone()` is already `true`), and reading `line.uuid` throws:

```
TypeError: Cannot read properties of undefined (reading 'uuid')
    at Proxy._resolvePaymentStatus
    at Proxy.handleMollieStatusResponse
```

The crash happens *after* the payment is already settled, so no transaction or payment is lost, but the cashier sees a confusing error dialog after every affected transaction.

## Fix

Add a guard in `handleMollieStatusResponse` and `_resolvePaymentStatus`: if there is no pending mollie payment line left, there is nothing to resolve, so return silently instead of dereferencing `undefined`.

## Verification

Reproduced and confirmed against production data (Odoo 19): server logs and the `mollie.pos.terminal.payments` record show the transaction had already reached `status=paid` about 0.6s before the duplicate `get_mollie_payment_status` call that crashes. The pattern recurs specifically on POS configs with more than one Mollie terminal.