### PR TITLE
[FIX] payment_mollie_official: Restrict description size to 255

### DIFF
--- a/payment_mollie_official/models/payment_transaction.py
+++ b/payment_mollie_official/models/payment_transaction.py
@@ -13,6 +13,9 @@ from odoo import _, api, fields, models, tools
 
 _logger = logging.getLogger(__name__)
 
+# Description size on Mollie side is 255
+DESCRIPTION_SIZE = 255
+
 
 class PaymentTransaction(models.Model):
     _inherit = 'payment.transaction'
@@ -464,7 +467,7 @@ class PaymentTransaction(models.Model):
                 unit_price = -abs(unit_price)
             lines_amount_total += line.price_total
             line_data = {
-                'description': line.name,
+                'description': line.name[:DESCRIPTION_SIZE],
                 'type': line_type,
                 'quantity': quantity,
                 'unitPrice': {
@@ -522,7 +525,7 @@ class PaymentTransaction(models.Model):
             lines_amount_total += line.price_total
 
             line_data = {
-                'description': line.name,
+                'description': line.name[:DESCRIPTION_SIZE],
                 'type': line_type,
                 'quantity': quantity,
                 'quantityUnit': line.product_uom_id.name or 'pcs',


### PR DESCRIPTION
On Mollie Api side, description field is limited to 255 characters. If customer activates `description_sale` field in products, as this is a Text field, it is not limited to 255 characters.

Error:

<img width="1428" height="305" alt="image" src="https://github.com/user-attachments/assets/b63db755-313d-400e-97c6-24a010a493b8" />


@pga-odoo @hreinberger 