### PR TITLE
[FIX] payment_mollie_official: 16.0.0.7 send voucher category of selected issuer

### DIFF
--- a/payment_mollie_official/__manifest__.py
+++ b/payment_mollie_official/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Mollie Payments Extended',
-    'version': '16.0.0.6',
+    'version': '16.0.0.7',
     'category': 'eCommerce',
     'license': 'LGPL-3',
     'author': 'Mollie',

--- a/payment_mollie_official/models/payment_transaction.py
+++ b/payment_mollie_official/models/payment_transaction.py
@@ -13,6 +13,17 @@ from odoo import _, api, fields, models, tools
 
 _logger = logging.getLogger(__name__)
 
+# Mollie voucher issuer ids embed the voucher type, e.g. 'edenred-belgium-eco',
+# 'pluxee-belgium-lunch'. Tokens are matched against the lowercased issuer id.
+MOLLIE_VOUCHER_ISSUER_TOKENS = {
+    'meal': ('meal', 'lunch', 'restaurant'),
+    'eco': ('eco',),
+    'gift': ('gift', 'cadeau', 'compliments'),
+    'sports': ('sport',),
+    'consume': ('consum',),
+    'additional': ('additional',),
+}
+
 
 class PaymentTransaction(models.Model):
     _inherit = 'payment.transaction'
@@ -402,13 +413,27 @@ class PaymentTransaction(models.Model):
                 category = line.product_id.product_tmpl_id._get_mollie_voucher_category()
                 if category:
                     line_data.update({
-                        'category': category[0]
+                        'category': self._mollie_voucher_category_for_issuer(category)
                     })
             lines.append(line_data)
         if self.fees:
             lines.append(self._mollie_prepare_fees_line())
 
         return lines
+
+    def _mollie_voucher_category_for_issuer(self, categories):
+        """ The order API accepts a single category per line: return the one the
+        selected voucher issuer can pay, else the first configured one.
+
+        :param list categories: voucher categories configured for the product
+        :return: category to send to mollie
+        :rtype: str
+        """
+        issuer = (self.mollie_payment_issuer or '').lower()
+        for category in categories:
+            if any(token in issuer for token in MOLLIE_VOUCHER_ISSUER_TOKENS.get(category, ())):
+                return category
+        return categories[0]
 
     def _mollie_prepare_fees_line(self):
         return {

--- a/payment_mollie_official/static/description/index.html
+++ b/payment_mollie_official/static/description/index.html
@@ -251,6 +251,15 @@
 
 <div class="card mx-auto w-md-75">
     <div class="card-header bg-200">
+        <h4 class="m-0">v16.0.0.7</h4>
+    </div>
+    <div class="card-body">
+        <div> <b class="text-warning"> UPDATE </b> Voucher payments: send the category matching the selected voucher issuer when a product allows several voucher types. </div>
+    </div>
+</div>
+
+<div class="card mx-auto w-md-75">
+    <div class="card-header bg-200">
         <h4 class="m-0">v16.0.0.6</h4>
     </div>
     <div class="card-body">

--- a/payment_mollie_official/tests/__init__.py
+++ b/payment_mollie_official/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_voucher_category

--- a/payment_mollie_official/tests/test_voucher_category.py
+++ b/payment_mollie_official/tests/test_voucher_category.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged('post_install', '-at_install')
+class TestMollieVoucherCategory(TransactionCase):
+
+    def test_category_follows_selected_issuer(self):
+        product = self.env['product.template'].create({'name': 'Voucher product'})
+        VoucherLine = self.env['mollie.voucher.line']
+        VoucherLine.create({'mollie_voucher_category': 'eco', 'product_ids': [(4, product.id)]})
+        VoucherLine.create({'mollie_voucher_category': 'gift', 'product_ids': [(4, product.id)]})
+        categories = product._get_mollie_voucher_category()
+        self.assertEqual(sorted(categories), ['eco', 'gift'])
+
+        def category_for(issuer):
+            tx = self.env['payment.transaction'].new({'mollie_payment_issuer': issuer})
+            return tx._mollie_voucher_category_for_issuer(categories)
+
+        self.assertEqual(category_for('monizze-belgium-gift'), 'gift')
+        self.assertEqual(category_for('edenred-belgium-eco'), 'eco')
+        # Unknown issuer or no issuer: previous behaviour, first configured category
+        self.assertEqual(category_for('unknown-issuer'), categories[0])
+        self.assertEqual(category_for(False), categories[0])


### PR DESCRIPTION
Linear: https://linear.app/droggol/issue/DRO-9682 · Jira: PIOD-263

## Problem

When a product is eligible for several voucher types (e.g. eco **and** gift), `_mollie_get_order_lines` always sent the first configured category to Mollie's Orders API. A customer paying with a gift voucher was then rejected because every line was flagged `eco`.

## Why not copy the 17/18/19 fix

17.0.0.6+ sends `lines[].categories` (array), but only because those branches moved to the Payments API. Odoo 16 still creates sale-order payments through the Orders API, whose `lines[].category` accepts a single string (Mollie "Integrating vouchers" guide).

## Fix

- Per line, send the category that matches the voucher issuer the customer selected at checkout (`mollie_payment_issuer`, e.g. `edenred-belgium-eco`, `pluxee-belgium-lunch`). Token map `MOLLIE_VOUCHER_ISSUER_TOKENS` + helper `_mollie_voucher_category_for_issuer`.
- No issuer or no match: first configured category, i.e. the previous behaviour. Never worse than before.
- Version 16.0.0.7 + release note.
- Regression test `tests/test_voucher_category.py` (no Mollie call).

## Verification

- Odoo shell on a local 16 DB, order with an eco+gift product: issuer `monizze-belgium-gift` → `gift`, `edenred-belgium-eco` → `eco`, meal issuer / no issuer → `eco` (fallback).
- `odoo-bin -i payment_mollie_official --test-tags /payment_mollie_official`: 0 failed, 0 errors of 1 test.
- `osg verify --changed`: 0 errors. `osg lint`: only a pre-existing warning in `account_payment_register.py`.

## Notes for reviewers

- Issuer id tokens were taken from Mollie's docs and not validated against a live account; please check the ids returned by "Sync methods" on a test profile contain `eco`, `gift`/`cadeau`, `meal`/`lunch`, `sport`.
- Separate issue, not changed here: the addon sends voucher category key `sports` while Mollie documents `sport_culture` (same on 17/18/19; `mollie_pos_terminal` already uses `sport_culture`).
